### PR TITLE
Minimal TravisCI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+#Ignore backup files from some Unix editors,
+*~
+*.swp
+*.bak
+
+#Ignore patches and any original files created by patch command
+*.diff
+*.patch
+*.orig
+*.rej
+
+#Ignore these hidden files from Mac OS X
+.DS_Store
+
+#The script will output a report file:
+mydois.txt
+
+#The script will output date-stamped report files:
+*.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+# TravisCI configuration file, see
+# https://docs.travis-ci.com/user/languages/r/
+language: r
+cache: packages
+sudo: false
+script: "Rscript checkmydois.R"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,17 @@
+Package: checkmydois
+Title: Verify your public research outpus are available by DOI
+Version: 0.1
+Authors@R: person("Ross", "Mounce", email = "ross.mounce@gmail.com",
+                  role = c("aut", "cre"))
+Description:
+  R code to check that the DOIs of your own authored research
+  outputs (not just articles!) aren't 404'ing. This leverages
+  your ORCID profile and your list of public works. (Public
+  works only)
+Depends: R (>= 3.1.0)
+License: MIT
+Imports:
+  httr,
+  dplyr,
+  rorcid
+LazyData: true


### PR DESCRIPTION
To see this in action you will need to turn on this repository in your TravisCI settings.

This include the ``.gitignore`` file from #3

Ideally you can refine the new ``DESCRIPTION`` file (e.g. what is a sensible minimum version of R to require?).

Right now this runs under TravisCI (with installation of dependencies), but fails on a DOI URL with:

```
...
Error in curl::curl_fetch_memory(url, handle = handle) : 
  Timeout was reached
Calls: http_status ... request_fetch -> request_fetch.write_memory -> <Anonymous> -> .Call
Execution halted
```

Full log via https://travis-ci.org/peterjc/checkmydois/builds/196985049
